### PR TITLE
ci: remove release input and add slack notifications

### DIFF
--- a/.github/workflows/tf-nightly.yml
+++ b/.github/workflows/tf-nightly.yml
@@ -73,7 +73,36 @@ jobs:
           TF_VAR_user_ocid: ${{ secrets.tf_oci_user }}
           TF_VAR_region: ${{ secrets.tf_oci_region }}
 
-
+  slack-notify:
+    name: Slack Notify if Failed Tests
+    needs: run-tests
+    runs-on: ubuntu-latest
+    if: needs.run-tests.result == 'failure'
+    steps:
+      - name: Notify Slack on Failure
+        uses: slackapi/slack-github-action@v1.25.0
+        if: failure()
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure <${{ github.server_url }}/${{ github.repository }}>*\n\n*Workflow Run*\n <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
 
 

--- a/.github/workflows/tf-prepare-release.yml
+++ b/.github/workflows/tf-prepare-release.yml
@@ -9,7 +9,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: main
           token: ${{ secrets.TF_TOKEN }}
 
 
@@ -23,6 +22,33 @@ jobs:
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           GITHUB_TOKEN: ${{ secrets.TF_TOKEN }}
 
-
-
-
+  slack-notify:
+    name: Slack Notify if Failed Tests
+    needs: prepare-release
+    runs-on: ubuntu-latest
+    if: needs.prepare-release.result == 'failure'
+    steps:
+      - name: Notify Slack on Failure
+        uses: slackapi/slack-github-action@v1.25.0
+        if: failure()
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure <${{ github.server_url }}/${{ github.repository }}>*\n\n*Workflow Run*\n <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/tf-release.yml
+++ b/.github/workflows/tf-release.yml
@@ -9,7 +9,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: main
           token: ${{ secrets.TF_TOKEN }}
 
       - name: Prepare release
@@ -22,4 +21,34 @@ jobs:
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           GITHUB_TOKEN: ${{ secrets.TF_TOKEN }}
 
+  slack-notify:
+    name: Slack Notify if Failed Tests
+    needs: tf-release
+    runs-on: ubuntu-latest
+    if: needs.tf-release.result == 'failure'
+    steps:
+      - name: Notify Slack on Failure
+        uses: slackapi/slack-github-action@v1.25.0
+        if: failure()
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure <${{ github.server_url }}/${{ github.repository }}>*\n\n*Workflow Run*\n <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 

--- a/.github/workflows/tf-test-compatibility.yml
+++ b/.github/workflows/tf-test-compatibility.yml
@@ -5,10 +5,6 @@ on:
         type: string
         description: "Minimum Terraform Version Supported by Module"
         default: 1.0
-      trigger-release:
-        type: boolean
-        description: "Whether or not to trigger a release"
-        default: false
 
 jobs:
   # Construct a set of terraform version numbers to test against
@@ -162,7 +158,7 @@ jobs:
           TF_VAR_region: ${{ secrets.tf_oci_region }}
 
   trigger-release:
-    if: ${{ inputs.trigger-release }}
+    if: github.ref == 'refs/heads/main'
     needs: [get-versions, run-tests]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tf-test-compatibility.yml
+++ b/.github/workflows/tf-test-compatibility.yml
@@ -165,7 +165,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        ref: main
         token: ${{ secrets.TF_TOKEN }}
     
     - name: Trigger release
@@ -178,4 +177,33 @@ jobs:
         GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
         GITHUB_TOKEN: ${{ secrets.TF_TOKEN }}
 
-
+  slack-notify:
+    name: Slack Notify if Failed Tests
+    needs: [get-versions, run-tests, trigger-release]
+    runs-on: ubuntu-latest
+    if: needs.get-versions.result == 'failure' || needs.run-tests.result == 'failure' || needs.trigger-release.result == 'failure'
+    steps:
+      - name: Notify Slack on Failure
+        uses: slackapi/slack-github-action@v1.25.0
+        if: failure()
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure <${{ github.server_url }}/${{ github.repository }}>*\n\n*Workflow Run*\n <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
Ensure release triggers only for main branch, making input redundant. Removed trigger release input. Add slack notifications. 

https://lacework.atlassian.net/browse/GROW-2760