### PR TITLE
ci: add slack notifications and fix fetch depth

### DIFF
--- a/.github/workflows/tf-nightly.yml
+++ b/.github/workflows/tf-nightly.yml
@@ -1,4 +1,3 @@
-
 on: 
   workflow_call:
     inputs:

--- a/.github/workflows/tf-prepare-release.yml
+++ b/.github/workflows/tf-prepare-release.yml
@@ -11,7 +11,30 @@ jobs:
         with:
           token: ${{ secrets.TF_TOKEN }}
 
-
+      - name: Notify Slack of Release
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": Preparing release for Terraform Module: ${{ github.repository }}"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.TF_SLACK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          
       - name: Prepare release
         shell: bash
         run: |

--- a/.github/workflows/tf-prepare-release.yml
+++ b/.github/workflows/tf-prepare-release.yml
@@ -10,6 +10,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.TF_TOKEN }}
+          fetch-depth: 0
+          ref: main
 
       - name: Notify Slack of Release
         uses: slackapi/slack-github-action@v1.25.0

--- a/.github/workflows/tf-release.yml
+++ b/.github/workflows/tf-release.yml
@@ -11,6 +11,30 @@ jobs:
         with:
           token: ${{ secrets.TF_TOKEN }}
 
+      - name: Notify Slack of Release
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": Releasing Terraform Module: ${{ github.repository }}"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.TF_SLACK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
       - name: Prepare release
         shell: bash
         run: |

--- a/.github/workflows/tf-release.yml
+++ b/.github/workflows/tf-release.yml
@@ -10,6 +10,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.TF_TOKEN }}
+          ref: ${{ github.ref }}
 
       - name: Notify Slack of Release
         uses: slackapi/slack-github-action@v1.25.0


### PR DESCRIPTION
Fetch depth on checkout need to be set to zero so scripts can compare against previous commits. Also some slack notifications are missing.

Issue:

https://lacework.atlassian.net/browse/GROW-2760