### PR TITLE
cI: update workflow with gcloud orgid and remote tf release candidates from testing

### DIFF
--- a/.github/workflows/tf-nightly.yml
+++ b/.github/workflows/tf-nightly.yml
@@ -71,6 +71,7 @@ jobs:
           TF_VAR_fingerprint: ${{ secrets.tf_oci_fingerprint }}
           TF_VAR_user_ocid: ${{ secrets.tf_oci_user }}
           TF_VAR_region: ${{ secrets.tf_oci_region }}
+          TF_VAR_organization_id: ${{ secrets.gcloud_org_id }}
 
   slack-notify:
     name: Slack Notify if Failed Tests

--- a/.github/workflows/tf-test-compatibility.yml
+++ b/.github/workflows/tf-test-compatibility.yml
@@ -156,6 +156,7 @@ jobs:
           TF_VAR_fingerprint: ${{ secrets.tf_oci_fingerprint }}
           TF_VAR_user_ocid: ${{ secrets.tf_oci_user }}
           TF_VAR_region: ${{ secrets.tf_oci_region }}
+          TF_VAR_organization_id: ${{ secrets.gcloud_org_id }}
 
   trigger-release:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/tf-test-compatibility.yml
+++ b/.github/workflows/tf-test-compatibility.yml
@@ -80,7 +80,7 @@ jobs:
         id: tflatest
         shell: bash
         run: |
-          VERSION=$(tfenv/bin/tfenv list-remote | grep '1\.[0-9]\.[0-9]' | grep -v beta | grep -v alpha | head -1)
+          VERSION=$(tfenv/bin/tfenv list-remote | grep '1\.[0-9]\.[0-9]' | grep -v beta | grep -v alpha | grep -v rc| head -1)
           echo $VERSION
           if [ "${{inputs.min-version}}" = "`echo -e "${{inputs.min-version}}\n${VERSION}" | sort -V | head -n1`" ]; then
             echo "Adding ${VERSION} to job matrix."


### PR DESCRIPTION
Summary:

Gcloud org id is missing causing tests to fail. Tests should not test against terraform release candidates.

Issue:

https://lacework.atlassian.net/browse/GROW-2760