### PR TITLE
ci: add AWS access keys to testing workflows

### DIFF
--- a/.github/workflows/tf-nightly.yml
+++ b/.github/workflows/tf-nightly.yml
@@ -72,6 +72,9 @@ jobs:
           TF_VAR_user_ocid: ${{ secrets.tf_oci_user }}
           TF_VAR_region: ${{ secrets.tf_oci_region }}
           TF_VAR_organization_id: ${{ secrets.gcloud_org_id }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.TF_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.TF_AWS_SESSION_TOKEN }}
 
   slack-notify:
     name: Slack Notify if Failed Tests

--- a/.github/workflows/tf-test-compatibility.yml
+++ b/.github/workflows/tf-test-compatibility.yml
@@ -157,6 +157,9 @@ jobs:
           TF_VAR_user_ocid: ${{ secrets.tf_oci_user }}
           TF_VAR_region: ${{ secrets.tf_oci_region }}
           TF_VAR_organization_id: ${{ secrets.gcloud_org_id }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.TF_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.TF_AWS_SESSION_TOKEN }}
 
   trigger-release:
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Summary:

Most tests use OIDC creds for AWS but a few require access key ENV vars. 

Issue:

https://lacework.atlassian.net/browse/GROW-2760