### PR TITLE
ci: add lacework profiles needed by aws cloudtrail tf module

### DIFF
--- a/.github/workflows/tf-nightly.yml
+++ b/.github/workflows/tf-nightly.yml
@@ -57,8 +57,6 @@ jobs:
       - name: Test Terraform
         shell: bash
         run: |
-          ls ~/.aws
-          cat ~/.aws/credentials
           terraform version
           ./scripts/ci_tests.sh
         env:

--- a/.github/workflows/tf-nightly.yml
+++ b/.github/workflows/tf-nightly.yml
@@ -35,7 +35,10 @@ jobs:
           --arg se "$LW_API_SECRET" \
           --arg su "$LW_SUBACCOUNT" \
           '{keyId: $ke, secret: $se, subAccount: $su, account: ($ac + ".lacework.net")}' > creds.json
-          lacework configure -j creds.json --noninteractive 
+          lacework configure -j creds.json --noninteractive
+          lacework configure -p main-account -j creds.json --noninteractive
+          lacework configure -p sub-account-1 -j creds.json --noninteractive
+          lacework configure -p sub-account-2 -j creds.json --noninteractive
         env:
           LW_ACCOUNT: ${{ secrets.tf_lw_account }}
           LW_API_KEY: ${{ secrets.tf_lw_api_key }}

--- a/.github/workflows/tf-nightly.yml
+++ b/.github/workflows/tf-nightly.yml
@@ -57,6 +57,8 @@ jobs:
       - name: Test Terraform
         shell: bash
         run: |
+          ls ~/.aws
+          cat ~/.aws/credentials
           terraform version
           ./scripts/ci_tests.sh
         env:

--- a/.github/workflows/tf-test-compatibility.yml
+++ b/.github/workflows/tf-test-compatibility.yml
@@ -120,7 +120,10 @@ jobs:
           --arg se "$LW_API_SECRET" \
           --arg su "$LW_SUBACCOUNT" \
           '{keyId: $ke, secret: $se, subAccount: $su, account: ($ac + ".lacework.net")}' > creds.json
-          lacework configure -j creds.json --noninteractive 
+          lacework configure -j creds.json --noninteractive
+          lacework configure -p main-account -j creds.json --noninteractive
+          lacework configure -p sub-account-1 -j creds.json --noninteractive
+          lacework configure -p sub-account-2 -j creds.json --noninteractive
         env:
           LW_ACCOUNT: ${{ secrets.tf_lw_account }}
           LW_API_KEY: ${{ secrets.tf_lw_api_key }}


### PR DESCRIPTION
Summary:

The aws cloudtrail terraform modules needs additional lacework profiles to test properly. 

Issue:

https://lacework.atlassian.net/browse/GROW-2760