### PR TITLE
ci: update workflows to use AWS creds in secrets if specified

### DIFF
--- a/.github/workflows/tf-nightly.yml
+++ b/.github/workflows/tf-nightly.yml
@@ -57,7 +57,18 @@ jobs:
           curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
           tfsec --version
 
-      - name: Test Terraform
+      - name: Detect AWS Creds
+        id: aws-cred-check
+        shell: bash
+        run: |
+          if [ "${{ secrets.AWS_ACCESS_KEY_ID }}" != '' ] && [ "${{ secrets.AWS_SECRET_ACCESS_KEY }}" != '' ]; then
+            echo "awscreds=true" >> $GITHUB_OUTPUT;
+          else
+            echo "awscreds=false" >> $GITHUB_OUTPUT;
+          fi
+
+      - name: Test Terraform with custom AWS creds
+        if: ${{ steps.aws-cred-check.outputs.awscreds != 'true' }}
         shell: bash
         run: |
           terraform version
@@ -75,6 +86,30 @@ jobs:
           TF_VAR_user_ocid: ${{ secrets.tf_oci_user }}
           TF_VAR_region: ${{ secrets.tf_oci_region }}
           TF_VAR_organization_id: ${{ secrets.gcloud_org_id }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          AWS_REGION: ${{ secrets.aws_region }}
+
+      - name: Test Terraform with standard AWS creds
+        if: ${{ steps.aws-cred-check.outputs.awscreds != 'false' }}
+        shell: bash
+        run: |
+          terraform version
+          ./scripts/ci_tests.sh
+        env:
+          ARM_SUBSCRIPTION_ID: ${{ secrets.tf_arm_subscription_id }}
+          ARM_TENANT_ID: ${{ secrets.tf_arm_tenant_id }}
+          ARM_CLIENT_ID: ${{ secrets.tf_arm_client_id }}
+          ARM_CLIENT_SECRET: ${{ secrets.tf_arm_client_secret }}
+          GOOGLE_PROJECT: ${{ secrets.tf_google_project }}
+          GOOGLE_CREDENTIALS: ${{ secrets.tf_google_credentials }}
+          OCI_PRIVATE_KEY: ${{ secrets.tf_oci_private_key }}
+          TF_VAR_tenancy_ocid: ${{ secrets.tf_oci_id }}
+          TF_VAR_fingerprint: ${{ secrets.tf_oci_fingerprint }}
+          TF_VAR_user_ocid: ${{ secrets.tf_oci_user }}
+          TF_VAR_region: ${{ secrets.tf_oci_region }}
+          TF_VAR_organization_id: ${{ secrets.gcloud_org_id }}
+
 
 
   slack-notify:

--- a/.github/workflows/tf-nightly.yml
+++ b/.github/workflows/tf-nightly.yml
@@ -67,6 +67,7 @@ jobs:
         if: ${{ inputs.use-custom-aws-creds }}
         shell: bash
         run: |
+          unset AWS_SESSION_TOKEN
           terraform version
           ./scripts/ci_tests.sh
         env:

--- a/.github/workflows/tf-nightly.yml
+++ b/.github/workflows/tf-nightly.yml
@@ -73,7 +73,6 @@ jobs:
           tfsec --version
 
       - name: Test Terraform
-        if: ${{ ! inputs.use-custom-aws-creds }}
         shell: bash
         run: |
           terraform version

--- a/.github/workflows/tf-nightly.yml
+++ b/.github/workflows/tf-nightly.yml
@@ -5,6 +5,11 @@ on:
         type: string
         description: "List of Terraform versions to test"
         default: '["1.0.0", "1.4", "1.5"]'
+      use-custom-aws-creds:
+        type: boolean
+        description: "Whether to use aws creds in secrets"
+        default: false
+
 jobs:
   run-tests:
     strategy:
@@ -57,18 +62,9 @@ jobs:
           curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
           tfsec --version
 
-      - name: Detect AWS Creds
-        id: aws-cred-check
-        shell: bash
-        run: |
-          if [ "${{ secrets.AWS_ACCESS_KEY_ID }}" != '' ] && [ "${{ secrets.AWS_SECRET_ACCESS_KEY }}" != '' ]; then
-            echo "awscreds=true" >> $GITHUB_OUTPUT;
-          else
-            echo "awscreds=false" >> $GITHUB_OUTPUT;
-          fi
 
       - name: Test Terraform with custom AWS creds
-        if: ${{ steps.aws-cred-check.outputs.awscreds == 'true' }}
+        if: ${{ inputs.use-custom-aws-creds }}
         shell: bash
         run: |
           terraform version
@@ -91,7 +87,7 @@ jobs:
           AWS_REGION: ${{ secrets.aws_region }}
 
       - name: Test Terraform with standard AWS creds
-        if: ${{ steps.aws-cred-check.outputs.awscreds == 'false' }}
+        if: ${{ ! inputs.use-custom-aws-creds }}
         shell: bash
         run: |
           terraform version

--- a/.github/workflows/tf-nightly.yml
+++ b/.github/workflows/tf-nightly.yml
@@ -60,8 +60,6 @@ jobs:
       - name: Test Terraform
         shell: bash
         run: |
-          ls ~/.aws
-          cat ~/.aws/credentials
           terraform version
           ./scripts/ci_tests.sh
         env:

--- a/.github/workflows/tf-nightly.yml
+++ b/.github/workflows/tf-nightly.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
+        if: ${{ ! inputs.use-custom-aws-creds }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::249446771485:role/tf-role-arc-generic
@@ -67,7 +68,6 @@ jobs:
         if: ${{ inputs.use-custom-aws-creds }}
         shell: bash
         run: |
-          unset AWS_SESSION_TOKEN
           terraform version
           ./scripts/ci_tests.sh
         env:

--- a/.github/workflows/tf-nightly.yml
+++ b/.github/workflows/tf-nightly.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
       - name: Test Terraform with custom AWS creds
-        if: ${{ steps.aws-cred-check.outputs.awscreds != 'true' }}
+        if: ${{ steps.aws-cred-check.outputs.awscreds == 'true' }}
         shell: bash
         run: |
           terraform version
@@ -91,7 +91,7 @@ jobs:
           AWS_REGION: ${{ secrets.aws_region }}
 
       - name: Test Terraform with standard AWS creds
-        if: ${{ steps.aws-cred-check.outputs.awscreds != 'false' }}
+        if: ${{ steps.aws-cred-check.outputs.awscreds == 'false' }}
         shell: bash
         run: |
           terraform version

--- a/.github/workflows/tf-nightly.yml
+++ b/.github/workflows/tf-nightly.yml
@@ -23,12 +23,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Configure AWS Credentials
+      - name: Configure AWS Credentials using OIDC
         if: ${{ ! inputs.use-custom-aws-creds }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::249446771485:role/tf-role-arc-generic
           aws-region: us-west-2
+
+      - name: Configure AWS Credentials using repo secrets
+        if: ${{ inputs.use-custom-aws-creds }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Install Lacework CLI
         shell: bash
@@ -63,31 +71,7 @@ jobs:
           curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
           tfsec --version
 
-
-      - name: Test Terraform with custom AWS creds
-        if: ${{ inputs.use-custom-aws-creds }}
-        shell: bash
-        run: |
-          terraform version
-          ./scripts/ci_tests.sh
-        env:
-          ARM_SUBSCRIPTION_ID: ${{ secrets.tf_arm_subscription_id }}
-          ARM_TENANT_ID: ${{ secrets.tf_arm_tenant_id }}
-          ARM_CLIENT_ID: ${{ secrets.tf_arm_client_id }}
-          ARM_CLIENT_SECRET: ${{ secrets.tf_arm_client_secret }}
-          GOOGLE_PROJECT: ${{ secrets.tf_google_project }}
-          GOOGLE_CREDENTIALS: ${{ secrets.tf_google_credentials }}
-          OCI_PRIVATE_KEY: ${{ secrets.tf_oci_private_key }}
-          TF_VAR_tenancy_ocid: ${{ secrets.tf_oci_id }}
-          TF_VAR_fingerprint: ${{ secrets.tf_oci_fingerprint }}
-          TF_VAR_user_ocid: ${{ secrets.tf_oci_user }}
-          TF_VAR_region: ${{ secrets.tf_oci_region }}
-          TF_VAR_organization_id: ${{ secrets.gcloud_org_id }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
-          AWS_REGION: ${{ secrets.aws_region }}
-
-      - name: Test Terraform with standard AWS creds
+      - name: Test Terraform
         if: ${{ ! inputs.use-custom-aws-creds }}
         shell: bash
         run: |
@@ -106,8 +90,6 @@ jobs:
           TF_VAR_user_ocid: ${{ secrets.tf_oci_user }}
           TF_VAR_region: ${{ secrets.tf_oci_region }}
           TF_VAR_organization_id: ${{ secrets.gcloud_org_id }}
-
-
 
   slack-notify:
     name: Slack Notify if Failed Tests

--- a/.github/workflows/tf-nightly.yml
+++ b/.github/workflows/tf-nightly.yml
@@ -37,6 +37,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
 
       - name: Install Lacework CLI
         shell: bash

--- a/.github/workflows/tf-nightly.yml
+++ b/.github/workflows/tf-nightly.yml
@@ -60,6 +60,8 @@ jobs:
       - name: Test Terraform
         shell: bash
         run: |
+          ls ~/.aws
+          cat ~/.aws/credentials
           terraform version
           ./scripts/ci_tests.sh
         env:

--- a/.github/workflows/tf-test-compatibility.yml
+++ b/.github/workflows/tf-test-compatibility.yml
@@ -121,6 +121,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
 
       - name: Install Lacework CLI
         shell: bash

--- a/.github/workflows/tf-test-compatibility.yml
+++ b/.github/workflows/tf-test-compatibility.yml
@@ -142,7 +142,41 @@ jobs:
           curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
           tfsec --version
 
-      - name: Test Terraform
+      - name: Detect AWS Creds
+        id: aws-cred-check
+        shell: bash
+        run: |
+          if [ "${{ secrets.AWS_ACCESS_KEY_ID }}" != '' ] && [ "${{ secrets.AWS_SECRET_ACCESS_KEY }}" != '' ]; then
+            echo "awscreds=true" >> $GITHUB_OUTPUT;
+          else
+            echo "awscreds=false" >> $GITHUB_OUTPUT;
+          fi
+
+      - name: Test Terraform with custom AWS creds
+        if: ${{ steps.aws-cred-check.outputs.awscreds != 'true' }}
+        shell: bash
+        run: |
+          terraform version
+          ./scripts/ci_tests.sh
+        env:
+          ARM_SUBSCRIPTION_ID: ${{ secrets.tf_arm_subscription_id }}
+          ARM_TENANT_ID: ${{ secrets.tf_arm_tenant_id }}
+          ARM_CLIENT_ID: ${{ secrets.tf_arm_client_id }}
+          ARM_CLIENT_SECRET: ${{ secrets.tf_arm_client_secret }}
+          GOOGLE_PROJECT: ${{ secrets.tf_google_project }}
+          GOOGLE_CREDENTIALS: ${{ secrets.tf_google_credentials }}
+          OCI_PRIVATE_KEY: ${{ secrets.tf_oci_private_key }}
+          TF_VAR_tenancy_ocid: ${{ secrets.tf_oci_id }}
+          TF_VAR_fingerprint: ${{ secrets.tf_oci_fingerprint }}
+          TF_VAR_user_ocid: ${{ secrets.tf_oci_user }}
+          TF_VAR_region: ${{ secrets.tf_oci_region }}
+          TF_VAR_organization_id: ${{ secrets.gcloud_org_id }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          AWS_REGION: ${{ secrets.aws_region }}
+
+      - name: Test Terraform with standard AWS creds
+        if: ${{ steps.aws-cred-check.outputs.awscreds != 'false' }}
         shell: bash
         run: |
           terraform version

--- a/.github/workflows/tf-test-compatibility.yml
+++ b/.github/workflows/tf-test-compatibility.yml
@@ -5,6 +5,10 @@ on:
         type: string
         description: "Minimum Terraform Version Supported by Module"
         default: 1.0
+      use-custom-aws-creds:
+        type: boolean
+        description: "Whether to use aws creds in secrets"
+        default: false
 
 jobs:
   # Construct a set of terraform version numbers to test against
@@ -142,18 +146,8 @@ jobs:
           curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
           tfsec --version
 
-      - name: Detect AWS Creds
-        id: aws-cred-check
-        shell: bash
-        run: |
-          if [ "${{ secrets.AWS_ACCESS_KEY_ID }}" != '' ] && [ "${{ secrets.AWS_SECRET_ACCESS_KEY }}" != '' ]; then
-            echo "awscreds=true" >> $GITHUB_OUTPUT;
-          else
-            echo "awscreds=false" >> $GITHUB_OUTPUT;
-          fi
-
       - name: Test Terraform with custom AWS creds
-        if: ${{ steps.aws-cred-check.outputs.awscreds != 'true' }}
+        if: ${{ inputs.use-custom-aws-creds }}
         shell: bash
         run: |
           terraform version
@@ -176,7 +170,7 @@ jobs:
           AWS_REGION: ${{ secrets.aws_region }}
 
       - name: Test Terraform with standard AWS creds
-        if: ${{ steps.aws-cred-check.outputs.awscreds != 'false' }}
+        if: ${{ ! inputs.use-custom-aws-creds }}
         shell: bash
         run: |
           terraform version

--- a/.github/workflows/tf-test-compatibility.yml
+++ b/.github/workflows/tf-test-compatibility.yml
@@ -107,12 +107,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Configure AWS Credentials
+      - name: Configure AWS Credentials using OIDC
         if: ${{ ! inputs.use-custom-aws-creds }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::249446771485:role/tf-role-arc-generic
           aws-region: us-west-2
+
+      - name: Configure AWS Credentials using repo secrets
+        if: ${{ inputs.use-custom-aws-creds }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Install Lacework CLI
         shell: bash
@@ -147,32 +155,8 @@ jobs:
           curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
           tfsec --version
 
-      - name: Test Terraform with custom AWS creds
-        if: ${{ inputs.use-custom-aws-creds }}
-        shell: bash
-        run: |
-          terraform version
-          ./scripts/ci_tests.sh
-        env:
-          ARM_SUBSCRIPTION_ID: ${{ secrets.tf_arm_subscription_id }}
-          ARM_TENANT_ID: ${{ secrets.tf_arm_tenant_id }}
-          ARM_CLIENT_ID: ${{ secrets.tf_arm_client_id }}
-          ARM_CLIENT_SECRET: ${{ secrets.tf_arm_client_secret }}
-          GOOGLE_PROJECT: ${{ secrets.tf_google_project }}
-          GOOGLE_CREDENTIALS: ${{ secrets.tf_google_credentials }}
-          OCI_PRIVATE_KEY: ${{ secrets.tf_oci_private_key }}
-          TF_VAR_tenancy_ocid: ${{ secrets.tf_oci_id }}
-          TF_VAR_fingerprint: ${{ secrets.tf_oci_fingerprint }}
-          TF_VAR_user_ocid: ${{ secrets.tf_oci_user }}
-          TF_VAR_region: ${{ secrets.tf_oci_region }}
-          TF_VAR_organization_id: ${{ secrets.gcloud_org_id }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
-          AWS_REGION: ${{ secrets.aws_region }}
+      - name: Test Terraform
 
-
-      - name: Test Terraform with standard AWS creds
-        if: ${{ ! inputs.use-custom-aws-creds }}
         shell: bash
         run: |
           terraform version

--- a/.github/workflows/tf-test-compatibility.yml
+++ b/.github/workflows/tf-test-compatibility.yml
@@ -150,6 +150,7 @@ jobs:
         if: ${{ inputs.use-custom-aws-creds }}
         shell: bash
         run: |
+          unset AWS_SESSION_TOKEN
           terraform version
           ./scripts/ci_tests.sh
         env:
@@ -168,6 +169,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
           AWS_REGION: ${{ secrets.aws_region }}
+
 
       - name: Test Terraform with standard AWS creds
         if: ${{ ! inputs.use-custom-aws-creds }}

--- a/.github/workflows/tf-test-compatibility.yml
+++ b/.github/workflows/tf-test-compatibility.yml
@@ -108,6 +108,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
+        if: ${{ ! inputs.use-custom-aws-creds }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::249446771485:role/tf-role-arc-generic
@@ -150,7 +151,6 @@ jobs:
         if: ${{ inputs.use-custom-aws-creds }}
         shell: bash
         run: |
-          unset AWS_SESSION_TOKEN
           terraform version
           ./scripts/ci_tests.sh
         env:


### PR DESCRIPTION
The terraform-aws-cloudtrail-controltower module needs a controltower enabled account to test against, thus the need to be able to specify alternate AWS creds. 

Testing:

tested workflows in non-main-branch

Issue:

https://lacework.atlassian.net/browse/GROW-2760