### PR TITLE
chore: replace tfsec with trivy

### DIFF
--- a/.github/workflows/tf-nightly.yml
+++ b/.github/workflows/tf-nightly.yml
@@ -66,11 +66,11 @@ jobs:
           terraform_version: ${{ matrix.version }}
           terraform_wrapper: false
 
-      - name: Install tfsec
+      - name: Install Trivy
         shell: bash
         run: |
-          curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
-          tfsec --version
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+          trivy --version
 
       - name: Test Terraform
         shell: bash

--- a/.github/workflows/tf-test-compatibility.yml
+++ b/.github/workflows/tf-test-compatibility.yml
@@ -150,11 +150,11 @@ jobs:
           terraform_version: ${{ matrix.version }}
           terraform_wrapper: false
 
-      - name: Install tfsec
+      - name: Install Trivy
         shell: bash
         run: |
-          curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
-          tfsec --version
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+          trivy --version
 
       - name: Test Terraform
 


### PR DESCRIPTION
Replace deprecated tfsec with Trivy for IaC security scanning                                                                                                            
   
tfsec has been archived by Aqua Security and its release assets are no longer available, causing CI to fail on installation. This replaces tfsec with Trivy, its official successor.